### PR TITLE
Update Security Context

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -14,7 +14,7 @@ const sha256 = data => {
 const createVerifyData = async (data, options) => {
   const transformedOptions = {
     ...options,
-    "@context": "https://w3id.org/identity/v1"
+    "@context": "https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld"
   };
   delete transformedOptions["type"];
   delete transformedOptions["id"];


### PR DESCRIPTION
From: https://socialhub.activitypub.rocks/t/what-are-projects-doing-about-ld-signatures-since-https-w3id-org-security-v1-went-away/3005/2

https://w3id.org/security/v1 is no longer resolvable and should be changed to https://w3c-ccg.github.io/security-vocab/contexts/security-v1.jsonld